### PR TITLE
Fix: Revert eslint dependencies to fix build break

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "root": true,
+  "rules": {}
+}

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "@types/find-config": "^1.0.4",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.10.0",
-    "@typescript-eslint/eslint-plugin": "^9.0.0",
-    "@typescript-eslint/parser": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.1",
+    "@typescript-eslint/parser": "^6.13.1",
     "babel-jest": "^29.7.0",
-    "eslint": "^9.0.0",
+    "eslint": "^8.54.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.2"


### PR DESCRIPTION
I reverted the following dependencies in package.json to their previous versions to resolve a build breakage caused by incompatible or non-existent versions:
- @typescript-eslint/eslint-plugin from ^9.0.0 to ^6.13.1
- @typescript-eslint/parser from ^9.0.0 to ^6.13.1
- eslint from ^9.0.0 to ^8.54.0

This change allows the project to build and run successfully, although pre-existing linting and type-checking errors remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new ESLint configuration to enable recommended linting rules for TypeScript.
  - Updated dependency versions for ESLint and TypeScript ESLint plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->