### PR TITLE
Docs: Add "Updating the Server" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,78 @@ docker run -e N8N_API_URL=http://your-n8n:5678/api/v1 \
   leonardsellem/n8n-mcp-server
 ```
 
+## Updating the Server
+
+How you update the server depends on how you initially installed it.
+
+### 1. Installed globally via npm
+
+If you installed the server using `npm install -g n8n-mcp-server`:
+
+1.  Open your terminal or command prompt.
+2.  Run the following command to get the latest version:
+    ```bash
+    npm install -g n8n-mcp-server@latest
+    ```
+3.  If the server is currently running (e.g., as a background process or service), you'll need to restart it for the changes to take effect.
+
+### 2. Installed from source
+
+If you cloned the repository and installed from source:
+
+1.  Open your terminal or command prompt.
+2.  Navigate to the directory where you cloned the project:
+    ```bash
+    cd path/to/n8n-mcp-server
+    ```
+3.  If you've made any local changes to the code that you want to keep, consider stashing them (optional):
+    ```bash
+    git stash
+    ```
+    You can apply them later with `git stash pop`.
+4.  Pull the latest changes from the repository (assuming you are on the `main` branch):
+    ```bash
+    git pull origin main
+    ```
+    If you are on a different branch, replace `main` with your branch name.
+5.  Install or update any changed dependencies:
+    ```bash
+    npm install
+    ```
+6.  Rebuild the project to include the latest updates:
+    ```bash
+    npm run build
+    ```
+7.  If you previously installed it globally from this source folder using `npm install -g .`, you might want to run this command again to update the global link:
+    ```bash
+    npm install -g .
+    ```
+8.  Restart the server.
+    *   If you run the server directly using a command like `node build/index.js` in your AI assistant's MCP configuration, ensure the path is still correct. Using `npm install -g .` and then `n8n-mcp-server` as the command should keep this consistent.
+
+### 3. Using Docker
+
+If you are running the server using Docker:
+
+1.  Pull the latest image from Docker Hub:
+    ```bash
+    docker pull leonardsellem/n8n-mcp-server:latest
+    ```
+2.  Stop and remove your old container. You'll need your container's name or ID (you can find it using `docker ps`):
+    ```bash
+    docker stop <your_container_name_or_id>
+    docker rm <your_container_name_or_id>
+    ```
+3.  Start a new container with the updated image. Use the same `docker run` command you used previously, including all your necessary environment variables (refer to the "Docker Installation" section for an example command). For instance:
+    ```bash
+    docker run -e N8N_API_URL=http://your-n8n:5678/api/v1 \
+      -e N8N_API_KEY=your_n8n_api_key \
+      -e N8N_WEBHOOK_USERNAME=username \
+      -e N8N_WEBHOOK_PASSWORD=password \
+      leonardsellem/n8n-mcp-server:latest
+    ```
+    Ensure you use `:latest` or the specific version tag you intend to run.
+
 ## Configuration
 
 Create a `.env` file in the directory where you'll run the server, using `.env.example` as a template:


### PR DESCRIPTION
This commit introduces a new section to the README.md file, titled "Updating the Server". This section provides you with clear, step-by-step instructions on how to update your n8n-mcp-server installation, covering three common installation methods:

1.  Installation via global npm package.
2.  Installation from source (git clone).
3.  Deployment via Docker.

The instructions include commands for fetching the latest code/image, updating dependencies, rebuilding (if necessary), and restarting the server. This addresses a community request for guidance on how to apply recent fixes and updates.