### PR TITLE
Feat: Prepare package for scoped npm publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # n8n MCP Server
 
+[![npm version](https://badge.fury.io/js/%40leonardsellem%2Fn8n-mcp-server.svg)](https://badge.fury.io/js/%40leonardsellem%2Fn8n-mcp-server)
+
 A Model Context Protocol (MCP) server that allows AI assistants to interact with n8n workflows through natural language.
 
 ## Overview
@@ -21,7 +23,7 @@ This MCP server provides tools and resources for AI assistants to manage n8n wor
 ### Install from npm
 
 ```bash
-npm install -g n8n-mcp-server
+npm install -g @leonardsellem/n8n-mcp-server
 ```
 
 ### Install from source
@@ -63,12 +65,12 @@ How you update the server depends on how you initially installed it.
 
 ### 1. Installed globally via npm
 
-If you installed the server using `npm install -g n8n-mcp-server`:
+If you installed the server using `npm install -g @leonardsellem/n8n-mcp-server`:
 
 1.  Open your terminal or command prompt.
 2.  Run the following command to get the latest version:
     ```bash
-    npm install -g n8n-mcp-server@latest
+    npm install -g @leonardsellem/n8n-mcp-server@latest
     ```
 3.  If the server is currently running (e.g., as a background process or service), you'll need to restart it for the changes to take effect.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "n8n-mcp-server",
+  "name": "@leonardsellem/n8n-mcp-server",
   "version": "0.1.0",
   "description": "Model Context Protocol (MCP) server for n8n workflow automation",
   "main": "build/index.js",
@@ -24,18 +24,34 @@
     "automation",
     "ai"
   ],
-  "author": "",
+  "author": "Leonard Sellem (https://sellem.me)",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/leonardsellem/n8n-mcp-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/leonardsellem/n8n-mcp-server/issues"
+  },
+  "homepage": "https://github.com/leonardsellem/n8n-mcp-server#readme",
+  "files": [
+    "build",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.7.0",
     "axios": "^1.6.2",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "find-config": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
     "@babel/plugin-transform-modules-commonjs": "^7.26.3",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.26.0",
+    "@types/find-config": "^1.0.4",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^9.0.0",


### PR DESCRIPTION
This commit prepares the project for publishing to npm under the scoped name `@leonardsellem/n8n-mcp-server`.

Changes include:
- Updated `package.json`:
  - Changed the `name` field to `@leonardsellem/n8n-mcp-server`.
  - Added/updated `author`, `repository`, `bugs`, `homepage`, and `files` fields for better npm presence.
- Updated `README.md`:
  - Changed npm installation commands to use the new scoped name (`npm install -g @leonardsellem/n8n-mcp-server`).
  - Added an npm version badge for the scoped package.
  - Updated the "Updating the Server" section for npm global installs to use the scoped name.