### PR TITLE
Add formatResourceUri tests

### DIFF
--- a/src/utils/resource-formatter.ts
+++ b/src/utils/resource-formatter.ts
@@ -135,8 +135,16 @@ export function formatExecutionStats(executions: Execution[]): Record<string, an
  * @returns Formatted resource URI
  */
 export function formatResourceUri(resourceType: 'workflow' | 'execution' | 'workflows' | 'execution-stats', id?: string): string {
-  if (id) {
-    return `n8n://${resourceType}s/${id}`;
+  let base: string = resourceType;
+
+  if (resourceType === 'workflow') {
+    base = 'workflows';
+  } else if (resourceType === 'execution') {
+    base = 'executions';
   }
-  return `n8n://${resourceType}`;
+
+  if (id) {
+    return `n8n://${base}/${id}`;
+  }
+  return `n8n://${base}`;
 }

--- a/tests/unit/tools/workflow/simple-tool.test.ts
+++ b/tests/unit/tools/workflow/simple-tool.test.ts
@@ -43,7 +43,7 @@ function getListWorkflowsToolDefinition() {
 }
 
 // Simple function to test workflow filtering
-function filterWorkflows(workflows, filter) {
+function filterWorkflows(workflows: Array<any>, filter: { active?: boolean }) {
   if (filter && typeof filter.active === 'boolean') {
     return workflows.filter(workflow => workflow.active === filter.active);
   }

--- a/tests/unit/utils/resource-formatter.test.ts
+++ b/tests/unit/utils/resource-formatter.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatResourceUri } from '../../../src/utils/resource-formatter.js';
+
+describe('formatResourceUri', () => {
+  it('should format workflow resource URIs', () => {
+    expect(formatResourceUri('workflow', '123')).toBe('n8n://workflows/123');
+  });
+
+  it('should format execution resource URIs', () => {
+    expect(formatResourceUri('execution', '456')).toBe('n8n://executions/456');
+  });
+
+  it('should not double pluralize when resourceType is already plural', () => {
+    expect(formatResourceUri('workflows', '789')).toBe('n8n://workflows/789');
+  });
+
+  it('should handle execution-stats with id', () => {
+    expect(formatResourceUri('execution-stats', 'abc')).toBe('n8n://execution-stats/abc');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure resource-formatter handles plural resources correctly
- unit test coverage for `formatResourceUri`
- fix types in `simple-tool.test.ts`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683ff9dbd22c83279f8c685e5f6a4dc7