### PR TITLE
Fix install command in docs

### DIFF
--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -12,7 +12,7 @@ This section covers everything you need to know to set up and configure the n8n 
 
 For a quick start, follow these steps:
 
-1. Install the server: `npm install -g n8n-mcp-server`
+1. Install the server: `npm install -g @leonardsellem/n8n-mcp-server`
 2. Create a `.env` file with your n8n API URL and API key
 3. Run the server: `n8n-mcp-server`
 4. Register the server with your AI assistant platform


### PR DESCRIPTION
## Summary
- fix global install command in setup quickstart guide

## Testing
- `npm test` *(fails: parameter 'workflows' implicitly has an 'any' type)*
- `npm run lint` *(fails: unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9d0a4f8832792aad943e078187a