### PR TITLE
Fix resource URI formatting

### DIFF
--- a/src/utils/resource-formatter.ts
+++ b/src/utils/resource-formatter.ts
@@ -134,9 +134,15 @@ export function formatExecutionStats(executions: Execution[]): Record<string, an
  * @param id Optional resource ID for specific resources
  * @returns Formatted resource URI
  */
-export function formatResourceUri(resourceType: 'workflow' | 'execution' | 'workflows' | 'execution-stats', id?: string): string {
+export function formatResourceUri(
+  resourceType: 'workflow' | 'execution' | 'workflows' | 'execution-stats',
+  id?: string,
+): string {
   if (id) {
-    return `n8n://${resourceType}s/${id}`;
+    const base = ['workflow', 'execution'].includes(resourceType)
+      ? `${resourceType}s`
+      : resourceType;
+    return `n8n://${base}/${id}`;
   }
   return `n8n://${resourceType}`;
 }

--- a/tests/unit/tools/workflow/simple-tool.test.ts
+++ b/tests/unit/tools/workflow/simple-tool.test.ts
@@ -43,7 +43,7 @@ function getListWorkflowsToolDefinition() {
 }
 
 // Simple function to test workflow filtering
-function filterWorkflows(workflows, filter) {
+function filterWorkflows(workflows: any[], filter: { active?: boolean }) {
   if (filter && typeof filter.active === 'boolean') {
     return workflows.filter(workflow => workflow.active === filter.active);
   }

--- a/tests/unit/utils/resource-formatter.test.ts
+++ b/tests/unit/utils/resource-formatter.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Resource formatter utility tests
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { formatResourceUri } from '../../../src/utils/resource-formatter.js';
+
+describe('formatResourceUri', () => {
+  it('appends "s" for singular resource types', () => {
+    expect(formatResourceUri('workflow', '1')).toBe('n8n://workflows/1');
+    expect(formatResourceUri('execution', '2')).toBe('n8n://executions/2');
+  });
+
+  it('does not append "s" for already plural resource types', () => {
+    expect(formatResourceUri('workflows', '3')).toBe('n8n://workflows/3');
+    expect(formatResourceUri('execution-stats', '4')).toBe('n8n://execution-stats/4');
+  });
+
+  it('returns URI without id when none is provided', () => {
+    expect(formatResourceUri('workflow')).toBe('n8n://workflow');
+    expect(formatResourceUri('workflows')).toBe('n8n://workflows');
+  });
+});


### PR DESCRIPTION
## Summary
- fix `formatResourceUri` to only pluralize singular resource types
- type fixes for workflow tool tests
- add resource formatter unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff9c39844832786dcfa0737c1528e