### PR TITLE
docs: fix wording in resource-formatter comment

### DIFF
--- a/src/utils/resource-formatter.ts
+++ b/src/utils/resource-formatter.ts
@@ -48,7 +48,7 @@ export function formatWorkflowDetails(workflow: Workflow): Record<string, any> {
     staticData: workflow.staticData,
     settings: workflow.settings,
     tags: workflow.tags,
-    // Exclude potentially sensitive or unuseful information
+    // Exclude potentially sensitive or unnecessary information
     // like pinData or other internal fields
   };
 }


### PR DESCRIPTION
## Summary
- update comment to use "unnecessary"

## Testing
- `npm test` *(fails: Parameter implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9ac2fc4832787b0889f231e51e9