### PR TITLE
Fix tests failing due to implicit any types

### DIFF
--- a/tests/unit/tools/workflow/simple-tool.test.ts
+++ b/tests/unit/tools/workflow/simple-tool.test.ts
@@ -4,8 +4,21 @@
 
 import { describe, it, expect } from '@jest/globals';
 
+interface MockWorkflow {
+  id: string;
+  name: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  nodes: any[];
+}
+
+interface WorkflowFilter {
+  active?: boolean;
+}
+
 // Mock workflow data
-const mockWorkflows = [
+const mockWorkflows: MockWorkflow[] = [
   {
     id: '1234abc',
     name: 'Test Workflow 1',
@@ -43,7 +56,7 @@ function getListWorkflowsToolDefinition() {
 }
 
 // Simple function to test workflow filtering
-function filterWorkflows(workflows, filter) {
+function filterWorkflows(workflows: MockWorkflow[], filter: WorkflowFilter): MockWorkflow[] {
   if (filter && typeof filter.active === 'boolean') {
     return workflows.filter(workflow => workflow.active === filter.active);
   }


### PR DESCRIPTION
## Summary
- fix the `simple-tool` workflow tests by adding explicit TypeScript types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff846683883279d7b598d893067a7