### PR TITLE
docs: require node 20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ These rules apply to all automated contributors working on this project.
 - CI must pass before requesting review.
 
 ## Environment
-- Node.js 18 or later is required.
+- Node.js 20 or later is required.
 
 ## Continuous Improvement
 - After completing a task, review this guide and update it with any lessons

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Base image using Node.js 18 (required by the project)
-FROM node:18-slim
+# Base image using Node.js 20 (LTS)
+FROM node:20-slim
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project provides a Model Context Protocol (MCP) server that empowers AI ass
 
 ### Prerequisites
 
-- Node.js 18 or later
+- Node.js 20 or later
 - n8n instance with API access enabled
 
 ### Install from npm

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -4,9 +4,9 @@ This guide covers the installation process for the n8n MCP Server.
 
 ## Prerequisites
 
-Before installing the n8n MCP Server, ensure you have:
+- Before installing the n8n MCP Server, ensure you have:
 
-- Node.js 18 or later installed
+- Node.js 20 or later installed
 - An n8n instance running and accessible via HTTP/HTTPS
 - API access enabled on your n8n instance
 - An API key with appropriate permissions (see [Configuration](./configuration.md))

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -57,7 +57,7 @@ This guide addresses common issues you might encounter when setting up and using
 
 **Possible Solutions:**
 1. **Check Node.js Version:**
-   - Ensure you're using Node.js 18 or later
+   - Ensure you're using Node.js 20 or later
    - Check with `node --version`
 
 2. **Check Environment Variables:**

--- a/tests/README.md
+++ b/tests/README.md
@@ -128,7 +128,7 @@ When adding new functionality to the project:
 
 If you encounter issues running the tests:
 
-- Ensure you're using Node.js 18 or later
+- Ensure you're using Node.js 20 or later
 - Run `npm install` to ensure all dependencies are installed
 - Check for ESM compatibility issues if importing CommonJS modules
 - Use `console.log` or `console.error` for debugging (removed in production)


### PR DESCRIPTION
## Summary
- bump minimum Node.js version mentioned in documentation to Node.js 20

## Testing
- `npm run lint` *(fails: no-explicit-any in src)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68402133d48c83279e65de02990a8290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all documentation references to require Node.js 20 or later instead of Node.js 18.
  - Made a minor formatting improvement in the installation guide prerequisites section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->