### PR TITLE
Fix parsing for workflow creation

### DIFF
--- a/docs/api/workflow-tools.md
+++ b/docs/api/workflow-tools.md
@@ -142,6 +142,9 @@ Creates a new workflow.
 }
 ```
 
+Nodes, connections, and tags may also be provided as JSON strings. They will be
+parsed automatically by the tool before validation.
+
 **Example Usage:**
 
 ```javascript

--- a/src/tools/workflow/create.ts
+++ b/src/tools/workflow/create.ts
@@ -23,9 +23,9 @@ export class CreateWorkflowHandler extends BaseWorkflowToolHandler {
     return this.handleExecution(async (args) => {
       const { name, nodes, connections, active, tags } = args;
 
-      const parsedNodes: any = parseIfJsonString(nodes);
-      const parsedConnections: any = parseIfJsonString(connections);
-      const parsedTags: any = parseIfJsonString(tags);
+      const parsedNodes: any = parseIfJsonString(nodes, { throwOnError: true, paramName: 'nodes' });
+      const parsedConnections: any = parseIfJsonString(connections, { throwOnError: true, paramName: 'connections' });
+      const parsedTags: any = parseIfJsonString(tags, { throwOnError: true, paramName: 'tags' });
       
       if (!name) {
         throw new N8nApiError('Missing required parameter: name');

--- a/src/tools/workflow/create.ts
+++ b/src/tools/workflow/create.ts
@@ -7,6 +7,7 @@
 import { BaseWorkflowToolHandler } from './base-handler.js';
 import { ToolCallResult, ToolDefinition } from '../../types/index.js';
 import { N8nApiError } from '../../errors/index.js';
+import { parseIfJsonString } from '../../utils/json.js';
 
 /**
  * Handler for the create_workflow tool
@@ -21,18 +22,22 @@ export class CreateWorkflowHandler extends BaseWorkflowToolHandler {
   async execute(args: Record<string, any>): Promise<ToolCallResult> {
     return this.handleExecution(async (args) => {
       const { name, nodes, connections, active, tags } = args;
+
+      const parsedNodes: any = parseIfJsonString(nodes);
+      const parsedConnections: any = parseIfJsonString(connections);
+      const parsedTags: any = parseIfJsonString(tags);
       
       if (!name) {
         throw new N8nApiError('Missing required parameter: name');
       }
-      
+
       // Validate nodes if provided
-      if (nodes && !Array.isArray(nodes)) {
+      if (parsedNodes && !Array.isArray(parsedNodes)) {
         throw new N8nApiError('Parameter "nodes" must be an array');
       }
-      
+
       // Validate connections if provided
-      if (connections && typeof connections !== 'object') {
+      if (parsedConnections && typeof parsedConnections !== 'object') {
         throw new N8nApiError('Parameter "connections" must be an object');
       }
       
@@ -43,9 +48,9 @@ export class CreateWorkflowHandler extends BaseWorkflowToolHandler {
       };
       
       // Add optional fields if provided
-      if (nodes) workflowData.nodes = nodes;
-      if (connections) workflowData.connections = connections;
-      if (tags) workflowData.tags = tags;
+      if (parsedNodes) workflowData.nodes = parsedNodes;
+      if (parsedConnections) workflowData.connections = parsedConnections;
+      if (parsedTags) workflowData.tags = parsedTags;
       
       // Create the workflow
       const workflow = await this.apiService.createWorkflow(workflowData);

--- a/src/tools/workflow/create.ts
+++ b/src/tools/workflow/create.ts
@@ -40,6 +40,11 @@ export class CreateWorkflowHandler extends BaseWorkflowToolHandler {
       if (parsedConnections && typeof parsedConnections !== 'object') {
         throw new N8nApiError('Parameter "connections" must be an object');
       }
+
+      // Validate tags if provided
+      if (parsedTags && !Array.isArray(parsedTags)) {
+        throw new N8nApiError('Parameter "tags" must be an array');
+      }
       
       // Prepare workflow object
       const workflowData: Record<string, any> = {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,12 @@
+import { safeJsonParse } from '../errors/index.js';
+
+/**
+ * Parse JSON if the provided value is a string containing JSON.
+ * Returns the original value if parsing fails or the value is not a string.
+ */
+export function parseIfJsonString(value: any): any {
+  if (typeof value !== 'string') return value;
+  const parsed = safeJsonParse(value);
+  return parsed !== null ? parsed : value;
+}
+

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,12 +1,22 @@
-import { safeJsonParse } from '../errors/index.js';
+import { safeJsonParse, N8nApiError } from '../errors/index.js';
 
 /**
  * Parse JSON if the provided value is a string containing JSON.
  * Returns the original value if parsing fails or the value is not a string.
  */
-export function parseIfJsonString(value: any): any {
+export function parseIfJsonString(
+  value: any,
+  options?: { throwOnError?: boolean; paramName?: string },
+): any {
   if (typeof value !== 'string') return value;
   const parsed = safeJsonParse(value);
-  return parsed !== null ? parsed : value;
+  if (parsed === null) {
+    if (options?.throwOnError) {
+      const name = options.paramName ?? 'value';
+      throw new N8nApiError(`Invalid JSON string for ${name} parameter`);
+    }
+    return value;
+  }
+  return parsed;
 }
 

--- a/tests/unit/tools/workflow/create-handler.test.ts
+++ b/tests/unit/tools/workflow/create-handler.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { CreateWorkflowHandler } from '../../../../src/tools/workflow/create.js';
+
+class MockApiService {
+  createWorkflow = jest.fn(async (workflow: any) => ({ id: '1', ...workflow }));
+}
+
+const envVars = {
+  N8N_API_URL: 'https://n8n.example.com/api/v1',
+  N8N_API_KEY: 'test-key',
+};
+
+describe('CreateWorkflowHandler', () => {
+  beforeEach(() => {
+    process.env.N8N_API_URL = envVars.N8N_API_URL;
+    process.env.N8N_API_KEY = envVars.N8N_API_KEY;
+  });
+
+  it('parses nodes and connections from JSON strings', async () => {
+    const handler = new CreateWorkflowHandler();
+    const service = new MockApiService();
+    (handler as any).apiService = service as any;
+
+    await handler.execute({
+      name: 'Test',
+      nodes: '[{"id":1}]',
+      connections: '{"main":[]}',
+      tags: '["tag"]',
+      active: true,
+    });
+
+    expect(service.createWorkflow).toHaveBeenCalledWith({
+      name: 'Test',
+      active: true,
+      nodes: [{ id: 1 }],
+      connections: { main: [] },
+      tags: ['tag'],
+    });
+  });
+
+  it('returns error when nodes is not an array after parsing', async () => {
+    const handler = new CreateWorkflowHandler();
+    const service = new MockApiService();
+    (handler as any).apiService = service as any;
+
+    const result = await handler.execute({
+      name: 'Bad',
+      nodes: '{"a":1}',
+      connections: '{}',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Parameter "nodes" must be an array');
+  });
+
+  it('returns error when nodes JSON is invalid', async () => {
+    const handler = new CreateWorkflowHandler();
+    const service = new MockApiService();
+    (handler as any).apiService = service as any;
+
+    const result = await handler.execute({
+      name: 'Bad',
+      nodes: '{invalid}',
+      connections: '{}',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Invalid JSON string for nodes parameter');
+  });
+});

--- a/tests/unit/utils/json.test.ts
+++ b/tests/unit/utils/json.test.ts
@@ -13,6 +13,10 @@ describe('parseIfJsonString', () => {
     expect(result).toBe(input);
   });
 
+  it('should throw when invalid JSON string is provided with throwOnError', () => {
+    expect(() => parseIfJsonString('{invalid}', { throwOnError: true, paramName: 'test' })).toThrow('Invalid JSON string for test parameter');
+  });
+
   it('should return original value when value is not a string', () => {
     const obj = { a: 1 };
     expect(parseIfJsonString(obj)).toBe(obj);

--- a/tests/unit/utils/json.test.ts
+++ b/tests/unit/utils/json.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseIfJsonString } from '../../../src/utils/json.js';
+
+describe('parseIfJsonString', () => {
+  it('should return parsed object when valid JSON string is provided', () => {
+    const result = parseIfJsonString('{"a":1}');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('should return original value when invalid JSON string is provided', () => {
+    const input = '{invalid}';
+    const result = parseIfJsonString(input);
+    expect(result).toBe(input);
+  });
+
+  it('should return original value when value is not a string', () => {
+    const obj = { a: 1 };
+    expect(parseIfJsonString(obj)).toBe(obj);
+  });
+});
+


### PR DESCRIPTION
## Summary
- parse nodes, connections and tags when they are JSON strings
- expose helper `parseIfJsonString`
- test JSON parsing utility

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved handling of input parameters for workflows, allowing automatic parsing of JSON strings for nodes, connections, and tags.

- **Bug Fixes**
  - Enhanced validation to ensure nodes and connections are correctly formatted before use.

- **Tests**
  - Added tests to verify the correct behavior of input parsing for JSON strings and non-string values.

- **Documentation**
  - Updated workflow tool documentation to explain support for JSON string inputs for nodes, connections, and tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->