### PR TITLE
Fix update_workflow issue

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,6 +7,7 @@
 import axios, { AxiosInstance } from 'axios';
 import { EnvConfig } from '../config/environment.js';
 import { handleAxiosError, N8nApiError } from '../errors/index.js';
+import { sanitizeWorkflowForApi } from '../utils/workflow-utils.js';
 
 /**
  * n8n API Client class for making requests to the n8n API
@@ -176,12 +177,8 @@ export class N8nApiClient {
       }
       
       // Remove read-only properties that cause issues
-      const workflowToCreate = { ...workflow };
+      const workflowToCreate = sanitizeWorkflowForApi(workflow);
       delete workflowToCreate.active; // Remove active property as it's read-only
-      delete workflowToCreate.id; // Remove id property if it exists
-      delete workflowToCreate.createdAt; // Remove createdAt property if it exists
-      delete workflowToCreate.updatedAt; // Remove updatedAt property if it exists
-      delete workflowToCreate.tags; // Remove tags property as it's read-only
       
       // Log request for debugging
       console.error('[DEBUG] Creating workflow with data:', JSON.stringify(workflowToCreate, null, 2));
@@ -204,11 +201,7 @@ export class N8nApiClient {
   async updateWorkflow(id: string, workflow: Record<string, any>): Promise<any> {
     try {
       // Remove read-only properties that cause issues with n8n API v1
-      const workflowToUpdate = { ...workflow };
-      delete workflowToUpdate.id; // Remove id property as it's read-only
-      delete workflowToUpdate.createdAt; // Remove createdAt property as it's read-only
-      delete workflowToUpdate.updatedAt; // Remove updatedAt property as it's read-only
-      delete workflowToUpdate.tags; // Remove tags property as it's read-only
+      const workflowToUpdate = sanitizeWorkflowForApi(workflow);
 
       // Log request for debugging
       if (this.config.debug) {

--- a/src/utils/workflow-utils.ts
+++ b/src/utils/workflow-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Workflow utility helpers
+ */
+
+/**
+ * Remove read-only and unsupported properties from a workflow object
+ * before sending it to the n8n API.
+ */
+export function sanitizeWorkflowForApi(workflow: Record<string, any>): Record<string, any> {
+  const sanitized = { ...workflow };
+  delete sanitized.id;
+  delete sanitized.createdAt;
+  delete sanitized.updatedAt;
+  delete sanitized.tags;
+  delete sanitized.pinData;
+  return sanitized;
+}

--- a/tests/mocks/axios-mock.ts
+++ b/tests/mocks/axios-mock.ts
@@ -3,6 +3,7 @@
  */
 
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { jest } from '@jest/globals';
 
 export interface MockResponse {
   data: any;
@@ -29,7 +30,7 @@ export const createMockAxiosInstance = () => {
   const mockRequests: Record<string, any[]> = {};
   const mockResponses: Record<string, MockResponse[]> = {};
   
-  const mockInstance = {
+  const mockInstance: any = {
     get: jest.fn(),
     post: jest.fn(),
     put: jest.fn(),

--- a/tests/unit/utils/workflow-utils.test.ts
+++ b/tests/unit/utils/workflow-utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from '@jest/globals';
+import { sanitizeWorkflowForApi } from '../../../src/utils/workflow-utils.js';
+
+describe('sanitizeWorkflowForApi', () => {
+  it('removes read-only properties', () => {
+    const workflow = {
+      id: '1',
+      name: 'Test',
+      createdAt: 'date',
+      updatedAt: 'date',
+      tags: ['a'],
+      pinData: { a: 1 },
+      nodes: [],
+      connections: {},
+    };
+
+    const sanitized = sanitizeWorkflowForApi(workflow);
+    expect(sanitized).toEqual({ name: 'Test', nodes: [], connections: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize workflows before create/update API calls to drop read-only fields like `pinData`
- add utility `sanitizeWorkflowForApi` with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842b198019883278a8e14bfdd7cb98c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved workflow handling by automatically removing read-only and unsupported properties before sending workflows to the API.
- **Tests**
  - Added unit tests to verify that read-only properties are correctly excluded from workflow objects.
- **Chores**
  - Updated test utilities for improved type clarity and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->