### PR TITLE
fix: resolve 'additional properties' error in update_workflow endpoint

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -204,8 +204,10 @@ export class N8nApiClient {
   async updateWorkflow(id: string, workflow: Record<string, any>): Promise<any> {
     try {
       // Remove read-only properties that cause issues with n8n API v1
+      // According to n8n API schema, only name, nodes, connections, settings, and staticData are allowed
       const workflowToUpdate = { ...workflow };
       delete workflowToUpdate.id; // Remove id property as it's read-only
+      delete workflowToUpdate.active; // Remove active property as it's read-only
       delete workflowToUpdate.createdAt; // Remove createdAt property as it's read-only
       delete workflowToUpdate.updatedAt; // Remove updatedAt property as it's read-only
       delete workflowToUpdate.tags; // Remove tags property as it's read-only


### PR DESCRIPTION
## Summary
Fixes #50 by resolving the "request/body must NOT have additional properties" error in the `update_workflow` endpoint.

## Changes
- **Modified `src/tools/workflow/update.ts`**: Only send allowed properties (`name`, `nodes`, `connections`, `settings`, `staticData`) instead of spreading entire workflow object
- **Updated `src/api/client.ts`**: Added filtering for `active` property which is read-only
- **Enhanced error handling**: Added user warnings when read-only properties (`active`, `tags`) are ignored
- **Updated documentation**: Clarified read-only property limitations in tool definitions

## Root Cause
The MCP server was spreading the entire workflow object (`{ ...currentWorkflow }`) which included read-only properties that n8n's strict API schema (`additionalProperties: false`) rejects.

## Test Plan
- [x] Build passes (`npm run build`)
- [x] Linting passes (`npm run lint`) 
- [x] Unit tests pass (`npm run test`)
- [x] Manual verification script exists for integration testing
- [x] Code follows n8n API schema requirements

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues with updating workflows by ensuring only allowed properties are included in the update request, preventing errors related to read-only fields.

* **Documentation**
  * Updated descriptions for workflow fields to clarify that certain properties are read-only and cannot be updated via this endpoint.
  * Added user-facing warnings when attempting to update read-only fields, with guidance on alternative tools for those actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->