### PR TITLE
fix: include execution data + resolve 415 on activate/deactivate

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -132,7 +132,9 @@ export class N8nApiClient {
    */
   async getExecution(id: string): Promise<any> {
     try {
-      const response = await this.axiosInstance.get(`/executions/${id}`);
+      const response = await this.axiosInstance.get(`/executions/${id}`, {
+        params: { includeData: true },
+      });
       return response.data;
     } catch (error) {
       throw handleAxiosError(error, `Failed to fetch execution ${id}`);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -249,7 +249,13 @@ export class N8nApiClient {
    */
   async activateWorkflow(id: string): Promise<any> {
     try {
-      const response = await this.axiosInstance.post(`/workflows/${id}/activate`);
+      // Pass empty string body and strip Content-Type header to avoid 415 errors
+      // from n8n API which rejects Content-Type: application/json on bodyless POST endpoints
+      const response = await this.axiosInstance.post(
+        `/workflows/${id}/activate`,
+        '',
+        { headers: { 'Content-Type': undefined } }
+      );
       return response.data;
     } catch (error) {
       throw handleAxiosError(error, `Failed to activate workflow ${id}`);
@@ -264,7 +270,13 @@ export class N8nApiClient {
    */
   async deactivateWorkflow(id: string): Promise<any> {
     try {
-      const response = await this.axiosInstance.post(`/workflows/${id}/deactivate`);
+      // Pass empty string body and strip Content-Type header to avoid 415 errors
+      // from n8n API which rejects Content-Type: application/json on bodyless POST endpoints
+      const response = await this.axiosInstance.post(
+        `/workflows/${id}/deactivate`,
+        '',
+        { headers: { 'Content-Type': undefined } }
+      );
       return response.data;
     } catch (error) {
       throw handleAxiosError(error, `Failed to deactivate workflow ${id}`);


### PR DESCRIPTION
## Summary

Two API client fixes in `src/api/client.ts`:

### 1. Include execution data in getExecution
- The n8n REST API requires `includeData=true` query parameter on `GET /api/v1/executions/{id}` to return the `data` field containing `resultData.runData` with node-level input/output
- Without this parameter, the `get_execution` MCP tool returns empty `nodeResults`, making it impossible to inspect per-node execution data
- Added `params: { includeData: true }` to the axios GET call

### 2. Fix 415 Unsupported Media Type on activate/deactivate workflow
- `POST /api/v1/workflows/{id}/activate` and `POST /api/v1/workflows/{id}/deactivate` are bodyless POST endpoints
- Axios automatically sends `Content-Type: application/json` even when no body is provided, causing n8n to return 415
- Fixed by passing an empty string body and explicitly setting `Content-Type: undefined` to strip the header from these requests

## Changes

```diff
# Fix 1: getExecution
- const response = await this.axiosInstance.get(`/executions/${id}`);
+ const response = await this.axiosInstance.get(`/executions/${id}`, {
+   params: { includeData: true },
+ });

# Fix 2: activateWorkflow / deactivateWorkflow
- const response = await this.axiosInstance.post(`/workflows/${id}/activate`);
+ const response = await this.axiosInstance.post(
+   `/workflows/${id}/activate`,
+   '',
+   { headers: { 'Content-Type': undefined } }
+ );
```

## Test plan

- [ ] Call `GET /api/v1/executions/{id}?includeData=true` and verify `data.resultData.runData` is present
- [ ] Confirm `get_execution` MCP tool now returns populated `nodeResults`
- [ ] Call `activate_workflow` and `deactivate_workflow` MCP tools and verify they succeed (no 415 error)
- [ ] Confirm curl equivalent works: `curl -s -X POST "https://{host}/api/v1/workflows/{id}/activate" -H "X-N8N-API-KEY: $KEY"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)