### PR TITLE
fix: filter workflow settings to only allowed API v1 properties on update

### DIFF
--- a/src/tools/workflow/update.ts
+++ b/src/tools/workflow/update.ts
@@ -39,12 +39,24 @@ export class UpdateWorkflowHandler extends BaseWorkflowToolHandler {
       // Get the current workflow to update
       const currentWorkflow = await this.apiService.getWorkflow(workflowId);
       
+      // Strip settings properties not accepted by the n8n public API v1 PUT schema.
+      // The GET response returns the full IWorkflowSettings (from n8n-workflow), but the
+      // PUT endpoint uses an OpenAPI schema with additionalProperties: false that only
+      // allows a subset of fields. Internal fields present in GET but absent from the
+      // OpenAPI spec cause: "request/body/settings must NOT have additional properties"
+      // See: n8n/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+      const rejectedSettingsKeys = ['binaryMode', 'timeSavedMode', 'credentialResolverId', 'redactionPolicy'];
+      const filteredSettings = { ...currentWorkflow.settings };
+      for (const key of rejectedSettingsKeys) {
+        delete filteredSettings[key];
+      }
+
       // Prepare update object with only allowed properties (per n8n API schema)
       const workflowData: Record<string, any> = {
         name: name !== undefined ? name : currentWorkflow.name,
         nodes: nodes !== undefined ? nodes : currentWorkflow.nodes,
         connections: connections !== undefined ? connections : currentWorkflow.connections,
-        settings: currentWorkflow.settings
+        settings: filteredSettings
       };
       
       // Add optional staticData if it exists


### PR DESCRIPTION
Fixes #71

  ## Root cause
The n8n public API v1 has an asymmetry between GET and PUT on `/workflows/{id}`:

  - **GET** returns the full `IWorkflowSettings` ([source](https://github.com/n8n-io/n8n/blob/master/packages/workflow/src/interfaces.ts)) which includes internal fields like `binaryMode`, `timeSavedMode`, `credentialResolverId`, `redactionPolicy`.

  - **PUT** validates against an OpenAPI schema with `additionalProperties: false` ([source](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml)) that does not list these fields.

  Since `update_workflow` copies `currentWorkflow.settings` as-is into the PUT body, any workflow with these extra settings fields fails with:

  > request/body/settings must NOT have additional properties (Status: 400)

  ## Fix

  Blacklist the known rejected fields (`binaryMode`, `timeSavedMode`, `credentialResolverId`, `redactionPolicy`) and strip them before sending the PUT request. This approach (vs whitelist) ensures new fields added to the OpenAPI spec are forwarded automatically.

  ## Tested

  Manually via MCP Inspector and Claude Code — `update_workflow` now succeeds on workflows that previously failed.